### PR TITLE
do not treat SIGINT as error state

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ function projector(script, exportName, args) {
       }
     });
 
-    proc.on('close', () => {
+    proc.on("close", (s, closeType /*: string */) => {
+      if (closeType === 'SIGINT') resolve('process exited by user command');
       reject(new Error('Never recieved a response from child process.'));
     });
   });


### PR DESCRIPTION
Currently if child process is manually exited, we throw an error. I think SIGINT should be treated differently.